### PR TITLE
rename module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "zfbrasil/repository-manager",
+    "name": "zfbrasil/repositorymanager",
     "description": "Manages a list of registered repositories",
     "require-dev": {
         "phpunit/phpunit": "~4.4"


### PR DESCRIPTION
I would like to rename it from repository-manager to repositorymanager since its easier to use - as namespace separator rather than camelCase indicator.